### PR TITLE
value_lexicon.h: Remove absl::hash_internal::Hash forward decl

### DIFF
--- a/src/s2/value_lexicon.h
+++ b/src/s2/value_lexicon.h
@@ -29,12 +29,6 @@
 #include "s2/util/gtl/dense_hash_set.h"
 
 class S2Point;
-namespace absl {
-namespace hash_internal {
-template <typename T>
-struct Hash;
-}  // namespace hash_internal
-}  // namespace absl
 
 // ValueLexicon is a class that maps distinct values to sequentially numbered
 // integer identifiers.  It automatically eliminates duplicates and uses a


### PR DESCRIPTION
This looks like it was added by include-what-you-use and may be causing a Darwin PPC compilation error.

https://github.com/google/s2geometry/issues/315#issuecomment-1552856928